### PR TITLE
[MSCC-61] Accessibiliy Recommendations, Service Name and Sign Up URL

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -53,6 +53,8 @@ class AppConfig @Inject()(implicit val runModeConfiguration: Configuration, envi
   lazy val whitelistExcludedPaths: Seq[Call] = whitelistConfig(ConfigKeys.whitelistExcludedPaths).map(path => Call("GET", path))
   lazy val whiteListEnabled: Boolean = getBoolean(ConfigKeys.whitelistEnabled)
 
+  lazy val govUkMtdVatSignUpGuidanceUrl = getString(ConfigKeys.govUkMtdVatSignUpGuidance)
+
   val features = new Features
 
 }

--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -34,4 +34,6 @@ object ConfigKeys {
 
   val progressiveDisclosureFeature: String = "features.progressiveDisclosure.enabled"
 
+  val govUkMtdVatSignUpGuidance = "govuk.mtdvat.signup.url"
+
 }

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -36,6 +36,7 @@
 
 @scripts = {
     <script src='@routes.Assets.at("javascript/softwareChoices.js")' type="text/javascript"></script>
+    @scriptElem.map(x => x)
 }
 
 @head = {
@@ -47,7 +48,7 @@
 
 @insideHeader = {
     @uiLayouts.header_nav(
-      navTitle = Some("software-choices-frontend"),
+      navTitle = Some(messages("common.service.name")),
       navTitleLink = None,
       showBetaLink = false,
       navLinks = None

--- a/app/views/software_choices_results.scala.html
+++ b/app/views/software_choices_results.scala.html
@@ -19,7 +19,16 @@
 
 @(softwareChoices: SoftwareChoicesViewModel, form: Form[SearchModel])(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@main_template(title = messages("softwareChoices.title"), bodyClasses = None) {
+@js = {
+    <script>
+        $(document).ready(function() {
+            //Jump to result, following accessibility recommendation
+            window.location.hash = '#results';
+        });
+    </script>
+}
+
+@main_template(title = messages("softwareChoices.title"), bodyClasses = None, scriptElem = Some(js)) {
 
     <h1>@messages("softwareChoices.title")</h1>
 
@@ -31,7 +40,7 @@
 
     @if(softwareChoices.foundProviders.isEmpty) {
 
-        <h2>@messages("softwareChoicesResults.noResults.title")</h2>
+        <h2 id="results">@messages("softwareChoicesResults.noResults.title")</h2>
         <p>@messages("softwareChoicesResults.noResults")</p>
 
         @if(appConfig.features.progressiveDisclosureEnabled()) {
@@ -45,7 +54,7 @@
         }
     } else {
 
-        <h2>@messages("softwareChoicesResults.results.title")</h2>
+        <h2 id="results">@messages("softwareChoicesResults.results.title")</h2>
         <p>@messages("softwareChoicesResults.results")</p>
 
         @softwareChoices.renderFoundProviders

--- a/app/views/templates/found_provider_template.scala.html
+++ b/app/views/templates/found_provider_template.scala.html
@@ -18,6 +18,12 @@
 
 <ul class="list list-bullet">
     @providers.map { provider =>
-        <li><a href="@provider.url" target="_blank">@provider.name <span class="visuallyhidden">@messages("common.newTab")</span></a></li>
+        <li>
+            <a href="@provider.url"
+               target="_blank"
+               data-journey-click="link:click:@{provider.name}"
+               aria-label='@messages("softwareChoices.provider.aria-label", provider.name)@messages("common.newTab")'>@provider.name
+            </a>
+        </li>
     }
 </ul>

--- a/app/views/templates/provider_template.scala.html
+++ b/app/views/templates/provider_template.scala.html
@@ -16,14 +16,16 @@
 
 @(category: String, providers: Seq[SoftwareProviderModel])(implicit messages: Messages)
 
-<h2>@category</h2>
+<h2 aria-label='@messages("softwareChoices.category.aria-label", category)'>@category</h2>
+
 <ul class="list list-bullet">
     @providers.map { provider =>
-      <li>
-        <a href="@provider.url"
-           target="_blank"
-           data-journey-click="link:click:@provider.name">@provider.name <span class="visuallyhidden">@messages("common.newTab")</span>
-        </a>
-      </li>
+        <li>
+            <a href="@provider.url"
+               target="_blank"
+               data-journey-click="link:click:@{provider.name}"
+               aria-label='@messages("softwareChoices.provider.aria-label", provider.name)@messages("common.newTab")'>@provider.name
+            </a>
+        </li>
     }
 </ul>

--- a/app/views/templates/search_bar_template.scala.html
+++ b/app/views/templates/search_bar_template.scala.html
@@ -16,12 +16,13 @@
 
 @import uk.gov.hmrc.play.views.html.helpers
 @import forms.SearchForm
+@import config.AppConfig
 
-@(form: Form[SearchModel])(implicit messages: Messages, request: Request[_])
+@(form: Form[SearchModel])(implicit messages: Messages, request: Request[_], appConfig: AppConfig)
 
 @helpers.form(action = controllers.routes.SoftwareChoicesController.search, 'novalidate -> "novalidate") {
 
-    <p>@messages("softwareChoices.search.text") <a href="#">@messages("softwareChoices.search.text.link")</a>.</p>
+    <p>@messages("softwareChoices.search.text") <a href="@appConfig.govUkMtdVatSignUpGuidanceUrl">@messages("softwareChoices.search.text.link")</a>.</p>
     <div class="panel panel-border-wide">
         <p>@messages("softwareChoices.text.p1")</p>
         <p>@messages("softwareChoices.text.p2")</p>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,3 +119,5 @@ whitelist {
 features {
   progressiveDisclosure.enabled = true
 }
+
+govuk.mtdvat.signup.url = "https://www.gov.uk/guidance/use-software-to-submit-your-vat-returns"

--- a/conf/messages
+++ b/conf/messages
@@ -1,3 +1,4 @@
+common.service.name = Find software for Making Tax Digital
 common.back = Back
 common.errorSummary.heading = There is a problem
 common.error = Error:
@@ -10,6 +11,9 @@ feedback.after = will help us to improve it.
 
 searchForm.term.missing = Enter the name of a software package
 searchForm.term.max = Enter less than {0} characters
+
+softwareChoices.category.aria-label = Software companies beginning with {0}
+softwareChoices.provider.aria-label = {0} software company website
 
 softwareChoices.title = Software that works with Making Tax Digital for VAT
 softwareChoices.search.label = Search for software that is connected to Making Tax Digital for VAT

--- a/test/MessagesSpec.scala
+++ b/test/MessagesSpec.scala
@@ -21,6 +21,9 @@ class MessagesSpec extends TestUtils {
 
   "Test message content is correct" in {
 
+    //Service name
+    messages("common.service.name") shouldBe CommonMessages.serviceName
+
     // Common Messages
     messages("common.back") shouldBe CommonMessages.back
     messages("common.errorSummary.heading") shouldBe CommonMessages.errorHeading

--- a/test/assets/messages/CommonMessages.scala
+++ b/test/assets/messages/CommonMessages.scala
@@ -18,6 +18,8 @@ package assets.messages
 
 object CommonMessages {
 
+  val serviceName = "Find software for Making Tax Digital"
+
   val back = "Back"
   val errorHeading = "There is a problem"
   val error = "Error:"

--- a/test/assets/messages/SoftwareChoicesMessages.scala
+++ b/test/assets/messages/SoftwareChoicesMessages.scala
@@ -26,4 +26,7 @@ object SoftwareChoicesMessages {
   val resultsHeader = "Results"
   val results = "We have found these software packages that work with Making Tax Digital for VAT:"
 
+  val providerAriaLabel: String => String = x => s"$x software company website"
+  val categoryAriaLabel: String => String = x => s"Software companies beginning with $x"
+
 }

--- a/test/utils/TestUtils.scala
+++ b/test/utils/TestUtils.scala
@@ -30,9 +30,7 @@ trait TestUtils extends UnitSpec with GuiceOneAppPerSuite with BeforeAndAfterEac
     super.beforeEach()
     appConfig.progressiveDisclosureEnabled(true)
   }
-
-  val opensInANewTabSuffix: String => String = _ + " opens in a new tab"
-
+  
   implicit lazy val fakeRequest = FakeRequest("GET", "/")
   lazy val injector: Injector = app.injector
   lazy val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]

--- a/test/views/SoftwareChoicesResultsViewSpec.scala
+++ b/test/views/SoftwareChoicesResultsViewSpec.scala
@@ -19,9 +19,8 @@ package views
 import assets.messages.{SearchMessages, SoftwareChoicesMessages}
 import assets.testContants.SoftwareProvidersTestConstants
 import forms.SearchForm
-import utils.ViewTestUtils
 
-class SoftwareChoicesResultsViewSpec extends ViewTestUtils with SoftwareProvidersTestConstants {
+class SoftwareChoicesResultsViewSpec extends ViewBaseSpec with SoftwareProvidersTestConstants {
 
   object Selectors {
     val pageHeading = "h1"
@@ -79,7 +78,7 @@ class SoftwareChoicesResultsViewSpec extends ViewTestUtils with SoftwareProvider
         }
 
         "have single provider for A section" in {
-          document.select(Selectors.providerSelector(1, 1)).text() shouldBe opensInANewTabSuffix(providers.allProviders.head.name)
+          document.select(Selectors.providerSelector(1, 1)).text() shouldBe providers.allProviders.head.name
         }
       }
 
@@ -101,7 +100,7 @@ class SoftwareChoicesResultsViewSpec extends ViewTestUtils with SoftwareProvider
         }
 
         "have a single provider for A section" in {
-          document.select(Selectors.providerSelector(1, 1)).text() shouldBe opensInANewTabSuffix(providers.allProviders.head.name)
+          document.select(Selectors.providerSelector(1, 1)).text() shouldBe providers.allProviders.head.name
         }
       }
     }

--- a/test/views/SoftwareChoicesSearchViewSpec.scala
+++ b/test/views/SoftwareChoicesSearchViewSpec.scala
@@ -19,9 +19,8 @@ package views
 import assets.messages.{CommonMessages, SearchMessages, SoftwareChoicesMessages}
 import assets.testContants.SoftwareProvidersTestConstants
 import forms.SearchForm
-import utils.ViewTestUtils
 
-class SoftwareChoicesSearchViewSpec extends ViewTestUtils with SoftwareProvidersTestConstants {
+class SoftwareChoicesSearchViewSpec extends ViewBaseSpec with SoftwareProvidersTestConstants {
 
   object Selectors {
     val pageHeading = "h1"
@@ -63,7 +62,7 @@ class SoftwareChoicesSearchViewSpec extends ViewTestUtils with SoftwareProviders
       }
 
       "have a single provider for A section" in {
-        document.select(Selectors.providerSelector(1, 1)).text() shouldBe opensInANewTabSuffix(providers.allProviders.head.name)
+        document.select(Selectors.providerSelector(1, 1)).text() shouldBe providers.allProviders.head.name
       }
     }
 
@@ -77,7 +76,7 @@ class SoftwareChoicesSearchViewSpec extends ViewTestUtils with SoftwareProviders
       }
 
       "have a single provider for A section" in {
-        document.select(Selectors.providerSelector(1, 1)).text() shouldBe opensInANewTabSuffix(providers.allProviders.head.name)
+        document.select(Selectors.providerSelector(1, 1)).text() shouldBe providers.allProviders.head.name
       }
     }
 

--- a/test/views/ViewBaseSpec.scala
+++ b/test/views/ViewBaseSpec.scala
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-package utils
+package views
 
+import assets.messages.{CommonMessages, SoftwareChoicesMessages}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
+import utils.TestUtils
 
-trait ViewTestUtils extends TestUtils {
+trait ViewBaseSpec extends TestUtils {
 
   lazy val parseView: HtmlFormat.Appendable => Document = x => Jsoup.parse(x.body)
+
+  val opensInANewTabSuffix: String => String = _ + CommonMessages.newTab
+
+  val softwareCategoryAriaLabel: String => String = x => SoftwareChoicesMessages.categoryAriaLabel(x)
+  val softwareCompanyAriaLabel: String => String = x => opensInANewTabSuffix(SoftwareChoicesMessages.providerAriaLabel(x))
 
 }

--- a/test/views/templates/ErrorTemplateViewSpec.scala
+++ b/test/views/templates/ErrorTemplateViewSpec.scala
@@ -16,9 +16,9 @@
 
 package views.templates
 
-import utils.ViewTestUtils
+import views.ViewBaseSpec
 
-class ErrorTemplateViewSpec extends ViewTestUtils {
+class ErrorTemplateViewSpec extends ViewBaseSpec {
 
   object Selectors {
     val heading = "h1"

--- a/test/views/templates/FoundProviderTemplateViewSpec.scala
+++ b/test/views/templates/FoundProviderTemplateViewSpec.scala
@@ -17,9 +17,9 @@
 package views.templates
 
 import assets.testContants.SoftwareProvidersTestConstants
-import utils.ViewTestUtils
+import views.ViewBaseSpec
 
-class FoundProviderTemplateViewSpec extends ViewTestUtils with SoftwareProvidersTestConstants {
+class FoundProviderTemplateViewSpec extends ViewBaseSpec with SoftwareProvidersTestConstants {
 
   object Selectors {
     val heading = "h2"
@@ -39,11 +39,15 @@ class FoundProviderTemplateViewSpec extends ViewTestUtils with SoftwareProviders
         s"for provider $i" should {
 
           "have the correct name" in {
-            document.select(Selectors.providerSelector(i + 1)).text() shouldBe opensInANewTabSuffix(providers(i).name)
+            document.select(Selectors.providerSelector(i + 1)).text() shouldBe providers(i).name
           }
 
           "have the correct link" in {
             document.select(Selectors.providerSelector(i + 1)).attr("href") shouldBe providers(i).url
+          }
+
+          "have the correct aria-label to support screenreaders" in {
+            document.select(Selectors.providerSelector(i + 1)).attr("aria-label") shouldBe softwareCompanyAriaLabel(providers(i).name)
           }
         }
       }

--- a/test/views/templates/ProgressiveDisclosureTemplateViewSpec.scala
+++ b/test/views/templates/ProgressiveDisclosureTemplateViewSpec.scala
@@ -17,9 +17,9 @@
 package views.templates
 
 import play.twirl.api.Html
-import utils.ViewTestUtils
+import views.ViewBaseSpec
 
-class ProgressiveDisclosureTemplateViewSpec extends ViewTestUtils {
+class ProgressiveDisclosureTemplateViewSpec extends ViewBaseSpec {
 
   object Selectors {
     val title = "span"

--- a/test/views/templates/ProviderTemplateViewSpec.scala
+++ b/test/views/templates/ProviderTemplateViewSpec.scala
@@ -17,9 +17,9 @@
 package views.templates
 
 import assets.testContants.SoftwareProvidersTestConstants
-import utils.ViewTestUtils
+import views.ViewBaseSpec
 
-class ProviderTemplateViewSpec extends ViewTestUtils with SoftwareProvidersTestConstants {
+class ProviderTemplateViewSpec extends ViewBaseSpec with SoftwareProvidersTestConstants {
 
   object Selectors {
     val heading = "h2"
@@ -34,8 +34,12 @@ class ProviderTemplateViewSpec extends ViewTestUtils with SoftwareProvidersTestC
 
       lazy val document = parseView(views.html.templates.provider_template(category, categoryAProviders))
 
-      s"have a the correct page heading" in {
+      s"have a the correct section heading" in {
         document.select(Selectors.heading).text() shouldBe category
+      }
+
+      s"have a the correct aria-label for the section heading" in {
+        document.select(Selectors.heading).attr("aria-label") shouldBe softwareCategoryAriaLabel(category)
       }
 
       for (i <- categoryAProviders.indices) {
@@ -43,11 +47,15 @@ class ProviderTemplateViewSpec extends ViewTestUtils with SoftwareProvidersTestC
         s"for provider $i" should {
 
           s"have the correct name" in {
-            document.select(Selectors.providerSelector(i + 1)).text() shouldBe opensInANewTabSuffix(categoryAProviders(i).name)
+            document.select(Selectors.providerSelector(i + 1)).text() shouldBe categoryAProviders(i).name
           }
 
           "have the correct link" in {
             document.select(Selectors.providerSelector(i + 1)).attr("href") shouldBe categoryAProviders(i).url
+          }
+
+          "have the correct aria-label to support screenreaders" in {
+            document.select(Selectors.providerSelector(i + 1)).attr("aria-label") shouldBe softwareCompanyAriaLabel(categoryAProviders(i).name)
           }
         }
       }

--- a/test/views/templates/SearchBarTemplateViewSpec.scala
+++ b/test/views/templates/SearchBarTemplateViewSpec.scala
@@ -18,9 +18,9 @@ package views.templates
 
 import assets.messages.SearchMessages
 import forms.SearchForm
-import utils.ViewTestUtils
+import views.ViewBaseSpec
 
-class SearchBarTemplateViewSpec extends ViewTestUtils {
+class SearchBarTemplateViewSpec extends ViewBaseSpec {
 
   object Selectors {
     val searchLabel = "label"
@@ -40,7 +40,7 @@ class SearchBarTemplateViewSpec extends ViewTestUtils {
 
       s"have a the correct search text with the correct link" in {
         document.select(Selectors.searchText).text() shouldBe s"${SearchMessages.text} ${SearchMessages.textLink}."
-        document.select(Selectors.searchTextLink).attr("href") shouldBe "#"
+        document.select(Selectors.searchTextLink).attr("href") shouldBe appConfig.govUkMtdVatSignUpGuidanceUrl
       }
 
       s"have a the correct indented text" in {


### PR DESCRIPTION
Includes the following Accessibility Recommendations:
- Aria-Label to provide context to the S/W Provider Category heading
- Aria-Label to provide context to the S/W Provider external website link
- JavaScript to jump to results on document.ready when a search is submitted

Includes change to the service name to: **Find software for Making Tax Digital**

Includes appConfig change for URL to GovUK MTD VAT Sign Up guidance.