### PR TITLE
SAR-5731 View and Controller for non js provider info

### DIFF
--- a/app/controllers/SoftwareInformationController.scala
+++ b/app/controllers/SoftwareInformationController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.AppConfig
+import javax.inject.{Inject, Singleton}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{AnyContent, _}
+import services.SoftwareChoicesService
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.software_choices_software_information
+
+@Singleton
+class SoftwareInformationController @Inject()(val mcc: MessagesControllerComponents,
+                                              val softwareChoicesService: SoftwareChoicesService
+                                             )(implicit val appConfig: AppConfig)
+  extends FrontendController(mcc) with I18nSupport {
+
+  def show(providerName: String): Action[AnyContent] = Action { implicit request =>
+    softwareChoicesService.returnProvider(providerName) match {
+      case Some(provider) => Ok(software_choices_software_information(provider))
+      case None => NoContent
+    }
+  }
+
+}

--- a/app/views/software_choices_software_information.scala.html
+++ b/app/views/software_choices_software_information.scala.html
@@ -1,0 +1,36 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import templates._
+@import views.utils.ServiceNameTitle
+
+
+@(provider: SoftwareProviderModel)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@main_template(title = ServiceNameTitle.fullTitle("softwareChoices.filter.title"),
+    bodyClasses = None) {
+    <div>
+        <p><a id="back" class="link-back" href="javascript:history.back()">@Messages("common.back")</a></p>
+    </div>
+
+    <h1 id="heading" class="form-group">@messages(provider.name)</h1>
+
+    @provider_info_template(provider)(messages)
+
+}
+
+

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,6 +4,9 @@ GET         /assets/*file                                    controllers.Assets.
 
 GET        /                                                 controllers.SoftwareChoicesController.show
 POST       /                                                 controllers.SoftwareChoicesController.search
+
+GET        /software-information                             controllers.SoftwareInformationController.show(providerName: String)
+
 POST       /ajax                                             controllers.SoftwareChoicesController.ajaxFilterSearch
 GET        /ajaxProvider                                     controllers.SoftwareChoicesController.ajaxProvider(providerName: String)
 

--- a/test/controllers/SoftwareInformationControllerSpec.scala
+++ b/test/controllers/SoftwareInformationControllerSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import _root_.utils.TestUtils
+import models.SoftwareProviderModel
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.mocks.MockSoftwareChoicesService
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+
+class SoftwareInformationControllerSpec extends TestUtils with MockSoftwareChoicesService {
+
+  object TestSoftwareInformationController extends SoftwareInformationController(
+    stubMessagesControllerComponents(),
+    mockSoftwareChoicesService
+  )(appConfig)
+
+  val softwareProviders: Seq[SoftwareProviderModel] = Seq(
+    SoftwareProviderModel("aName", "aUrl"),
+    SoftwareProviderModel("anotherName", "anotherUrl"),
+    SoftwareProviderModel("andAnotherName", "andAnotherUrl")
+  )
+
+  "SoftwareInformationController.softwareInformation" should {
+    "return the provider json if the name is valid" in {
+      mockReturnProvider(Some(softwareProviders.head))
+      val result = TestSoftwareInformationController.show("aName")(FakeRequest())
+
+      status(result) shouldBe OK
+      contentType(result) shouldBe Some("text/html")
+      charset(result) shouldBe Some("utf-8")
+    }
+
+    "return no content if the name is not in list" in {
+      mockReturnProvider(None)
+      val result = TestSoftwareInformationController.show("wrongName")(FakeRequest())
+
+      status(result) shouldBe NO_CONTENT
+    }
+  }
+}

--- a/test/views/SoftwareInformationViewSpec.scala
+++ b/test/views/SoftwareInformationViewSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import assets.testContants.SoftwareProvidersTestConstants
+import org.jsoup.nodes.Element
+
+
+class SoftwareInformationViewSpec extends ViewBaseSpec with SoftwareProvidersTestConstants {
+
+  object Messages {
+    val backButton = "Back"
+    val heading = "aName"
+
+  }
+
+  "The software information page" should {
+
+    lazy val document = parseView(views.html.software_choices_software_information(providerA))
+    lazy val body: Element = document.getElementById("content")
+
+    "have a back button" in {
+      body.select("p").text shouldBe Messages.backButton
+    }
+    "have a heading" in {
+      body.select("h1").text shouldBe Messages.heading
+    }
+  }
+}


### PR DESCRIPTION
New Controller and View for the Software Provider information for non js users.

Content and relevant tests added